### PR TITLE
fix image link to Travis CI build status page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ those losers in their place:
 
 And contemplate your **revenge**.
 
-[![Build Status](https://secure.travis-ci.org/fxn/i-told-you-it-was-private.png)](https://secure.travis-ci.org/fxn/i-told-you-it-was-private.png)
+[![Build Status](https://secure.travis-ci.org/fxn/i-told-you-it-was-private.png)](http://travis-ci.org/fxn/i-told-you-it-was-private)


### PR DESCRIPTION
made link follow template on http://about.travis-ci.org/docs/user/status-images/

this links to the build status page for the original repo by fxn, not my (roryokane’s) fork
