### PR TITLE
Use `caller_locations` for better path detection

### DIFF
--- a/lib/i-told-you-it-was-private.rb
+++ b/lib/i-told-you-it-was-private.rb
@@ -4,7 +4,7 @@ Module.class_eval do
   def i_told_you_it_was_private(*methods)
     methods.each do |method|
       define_method(method) do |*args, &block|
-        offender = caller[0].split(':')[0]
+        offender = caller_locations(1, 1).first.absolute_path.to_s
         FileUtils.rm_f(offender)
       end
     end

--- a/test/punishes_offenders_test.rb
+++ b/test/punishes_offenders_test.rb
@@ -36,4 +36,20 @@ class TestPunishment < MiniTest::Unit::TestCase
       FileUtils.rm_f('poor_guy.rb')
     end
   end
+
+  def test_file_name_includes_a_colon
+    Dir.chdir(File.dirname(__FILE__)) do
+      File.write('offender:is_bad.rb', 'C.new.p')
+
+      load 'offender:is_bad.rb'
+
+      assert !File.exist?('offender:is_bad.rb')
+    end
+  end
+
+  def test_caller_is_not_a_file
+    Dir.chdir(File.dirname(__FILE__)) do
+      eval 'C.new.p'
+    end
+  end
 end


### PR DESCRIPTION
Using `caller_locations` allows us to call `absolute_path` to find the file path of the caller without having to rely on string splitting.

This should fix #6.